### PR TITLE
feat(systick): Implement systick_wait() function to let clocks stabilize

### DIFF
--- a/blinky.uvprojx
+++ b/blinky.uvprojx
@@ -439,6 +439,16 @@
               <FileType>1</FileType>
               <FilePath>.\uart_interrupt.c</FilePath>
             </File>
+            <File>
+              <FileName>systick.c</FileName>
+              <FileType>1</FileType>
+              <FilePath>.\systick.c</FilePath>
+            </File>
+            <File>
+              <FileName>systick.h</FileName>
+              <FileType>5</FileType>
+              <FilePath>.\systick.h</FilePath>
+            </File>
           </Files>
         </Group>
         <Group>

--- a/led.c
+++ b/led.c
@@ -1,6 +1,6 @@
 #include "led.h"
 #include "test.h"
-//#include "defines.h"
+#include "systick.h"
 
 // Port F Initialization Function
 // The steps to initialize were followed through using the datasheet section 10.3
@@ -12,6 +12,7 @@
 void port_f_initialization(void)
 {
 	SYSCTL_RCGCGPIO_R |= 0x20u;				// enable clock gating for port f
+	systick_wait_5ms(1);
 	GPIO_PORTF_DIR_R |= 0x0Eu;				// PF4 PF0 to input 0, PF3-1 to output 1
 	GPIO_PORTF_AFSEL_R &= ~0x1Fu;			// Disable alternative function
 	GPIO_PORTF_PCTL_R &= ~0x1Fu;			// Clear bits to set as GPIO

--- a/main.c
+++ b/main.c
@@ -3,6 +3,7 @@
 #include "led.h"
 #include "uart_busy_wait.h"
 #include "uart_interrupt.h"
+#include "systick.h"
 #include "test.h"
 
 int main(void)
@@ -11,10 +12,9 @@ int main(void)
 	unsigned char color[100];			// static buffer to hold color strings such as "red", "blue", etc
 	unsigned long color_ptr = 0;	// pointer to keep track of the color buffer to "build" the string properly
 	bool string_complete = false;	// flag to check if string was completely built after user hit enter, used to reset color_ptr
+	systick_initialization();
 	port_f_initialization();
-	delay(1000000);
 	uart0_interrupt_initialization();
-	delay(1000000);
 	// Global interrupts enabled by default.
 
 	// main loop

--- a/systick.c
+++ b/systick.c
@@ -1,0 +1,48 @@
+#include "systick.h"
+
+// Use systick_wait() functions set at different delays to let the clocks stabilize in initialization functions
+//	i.e. uart0_interrupt_initialization() and port_f_initialization()
+
+#define SYSTICK_RELOAD_MAX 0x00FFFFFF		// Max is 24 bits
+
+void systick_initialization(void)
+{
+	NVIC_ST_CTRL_R = 0;			// disable systick while initializing it
+	NVIC_ST_CTRL_R = 0x01;	// Set bit 0 to enable it, clear bit 2 to disable systick interrupts
+													// clear bit 3 to set CLK_SRC as PIOSC
+}
+
+void systick_wait_reload(uint32_t reload)
+{
+	// If the value is > the max, then we should set it to max as a check
+	if (reload > SYSTICK_RELOAD_MAX)
+	{
+		reload = SYSTICK_RELOAD_MAX;
+	}
+	
+	// The -1 because the COUNT bit in ST_CTRL_R triggers when CURRENT goes from 1 to 0. We START counting from delay.
+	// I.e. if the RELOAD value is 10, it would count like so: 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0. Starting FROM 10, and counting TO 0 is 11 counts.
+	// 	To make sure the reload value is calculated correctly, we need to -1. 
+	NVIC_ST_RELOAD_R = reload - 1;
+	NVIC_ST_CURRENT_R = 0;	// Set current to 0 to set the COUNT bit 16 in NVIC_ST_CTRL_R
+	
+	// Keep delaying until the COUNT bit is set.
+	while ((NVIC_ST_CTRL_R & 0x00010000) == 0);
+}
+
+// Used to delay after setting clocks and letting them set in UART and GPIO Port initialization functions
+// Assume 16 MHz clock using PIOSC
+//
+// Calculations: COUNT of 80k in systick_wait_5ms(80000)
+// Formula is delay = count * clock tick
+// desired delay = 5ms
+// clock tick = 62.5ns
+//	1/F where Frequency is 16MHz
+// count = 5ms/62.5ns = 80000
+void systick_wait_5ms(uint32_t iterations)
+{
+	for (uint32_t i = 0; i < iterations; i++)
+	{
+		systick_wait_reload(80000);
+	}
+}

--- a/systick.h
+++ b/systick.h
@@ -1,0 +1,11 @@
+#ifndef SYSTICK_H
+#define SYSTICK_H
+#include "tm4c123gh6pm.h"		// vendor provided header
+#include <stdint.h>
+
+void systick_initialization(void);
+void systick_wait_reload(uint32_t reload);
+void systick_wait_5ms(uint32_t iterations);
+void systick_test(void);
+
+#endif 	// SYSTICK_H

--- a/test.c
+++ b/test.c
@@ -1,10 +1,9 @@
-#include "tm4c123gh6pm.h"
 #include "test.h"
-#include "ring_buffer.h"
 
 // Test functions
 
 // Simple delay function just to quickly test certain functions
+// Replaced by systick delay function
 void delay(unsigned long delay)
 {
 	unsigned long i;
@@ -62,4 +61,3 @@ void test_ring_buffer(void)
 		delay(1000000);
 	}
 }
-

--- a/test.h
+++ b/test.h
@@ -1,4 +1,11 @@
+#ifndef TEST_H
+#define TEST_H
+
 #include "tm4c123gh6pm.h"    // Device header
+#include "ring_buffer.h"
+#include "systick.h"
+#include "led.h"
 
 void delay(unsigned long delay);
 void test_ring_buffer(void);
+#endif	// TEST_H

--- a/uart_interrupt.c
+++ b/uart_interrupt.c
@@ -1,4 +1,5 @@
 #include "uart_interrupt.h"
+#include "systick.h"
 
 #define NULL 0
 #define TRUE 1
@@ -66,7 +67,9 @@ struct ring_buffer tx_ring_buffer =
 void uart0_interrupt_initialization(void)
 {
 	SYSCTL_RCGCUART_R |= 0x01;		// Enable clock gating for UART0
+	systick_wait_5ms(1);
 	SYSCTL_RCGCGPIO_R |= 0x01;		// Enable clock gating for Port A
+	systick_wait_5ms(1);
 	GPIO_PORTA_AFSEL_R = 0x03;		// Alternate function enabled because UART
 	GPIO_PORTA_PCTL_R |= 0x11;		// 4 bit wide PMCs, setting PMC0 and PMC1 according to page 1351
 	GPIO_PORTA_DEN_R |= 0x03;			// Enable digital on PA1-0


### PR DESCRIPTION
Use the function systick_wait_5ms() after turning on the clock for Ports and UART in their initialization functions. This is to use an accurate delay for maximum efficiency rather than banking on if a software implemented for loop or while loop delay would result in the same result.