### PR TITLE
feat(led): Implement colors.c to turn on corresponding LED color

### DIFF
--- a/blinky.uvprojx
+++ b/blinky.uvprojx
@@ -449,6 +449,16 @@
               <FileType>5</FileType>
               <FilePath>.\systick.h</FilePath>
             </File>
+            <File>
+              <FileName>colors.h</FileName>
+              <FileType>5</FileType>
+              <FilePath>.\colors.h</FilePath>
+            </File>
+            <File>
+              <FileName>colors.c</FileName>
+              <FileType>1</FileType>
+              <FilePath>.\colors.c</FilePath>
+            </File>
           </Files>
         </Group>
         <Group>

--- a/colors.c
+++ b/colors.c
@@ -1,0 +1,161 @@
+#include "colors.h"
+
+
+Colors get_color(char* static_buffer, unsigned long length, unsigned long* ptr, bool* string_complete)
+{
+	// Check if we are building a new string.
+	if (*string_complete)
+	{
+		*string_complete = false;
+		*ptr = 0;			// If the user completed typing a string in the previous iteration, then we should reset the pointer
+									// 	to build the string properly on the next iteration starting from the beginning of the buffer.
+									// This line of code was refactored from the uart_interrupt0_get_string() function due to the programming logic.
+	}
+
+	// Continue getting the string until it's complete, i.e. the user hits enter.
+	while (!(*string_complete))
+	{
+		uart0_interrupt_get_string(static_buffer, length, ptr, string_complete);
+	}
+	
+	// Return the corresponding color from the Colors enum.
+	if (strings_compare_colors_case_insensitive(static_buffer, "red"))
+	{
+		return RED;
+	}
+	else if (strings_compare_colors_case_insensitive(static_buffer, "blue"))
+	{
+		return BLUE;
+	}
+	else if (strings_compare_colors_case_insensitive(static_buffer, "green"))
+	{
+		return GREEN;
+	}
+	else if (strings_compare_colors_case_insensitive(static_buffer, "yellow"))
+	{
+		return YELLOW;
+	}
+	else if (strings_compare_colors_case_insensitive(static_buffer, "pink"))
+	{
+		return PINK;
+	}
+	else if (strings_compare_colors_case_insensitive(static_buffer, "cyan"))
+	{
+		return CYAN;
+	}
+	else if (strings_compare_colors_case_insensitive(static_buffer, "white"))
+	{
+		return WHITE;
+	}
+	else if (strings_compare_colors_case_insensitive(static_buffer, "black"))
+	{
+		return BLACK;
+	}
+	else
+	{
+		return NO_COLOR;
+	}
+}
+
+// Simple switch statement on the incoming enum value to turn on the corresponding LED color.
+// If no valid color was entered, then it should also turn the LED off.
+void led_turn_on_color(Colors led_color)
+{
+	switch (led_color)
+	{
+		case RED:
+			GPIO_PORTF_DATA_R = 0x02;
+			break;
+		
+		case BLUE:
+			GPIO_PORTF_DATA_R = 0x04;
+			break;
+		
+		case GREEN:
+			GPIO_PORTF_DATA_R = 0x08;
+			break;
+		
+		case YELLOW:
+			GPIO_PORTF_DATA_R = 0x0A;
+			break;
+		
+		case PINK:
+			GPIO_PORTF_DATA_R = 0x06;
+			break;
+		
+		case CYAN:
+			GPIO_PORTF_DATA_R = 0x0C;
+			break;
+		
+		case WHITE:
+			GPIO_PORTF_DATA_R = 0x0E;
+			break;
+		
+		case BLACK: 
+			GPIO_PORTF_DATA_R = 0x00;
+			break;
+		
+		case NO_COLOR:
+			GPIO_PORTF_DATA_R = 0x00;
+			break;
+	}
+}
+
+// Function to compare case insenstiive strings.
+// This is so if the user types RED or Red or red, it shouldn't matter when trying to choose the LED color.
+//
+// BUG: When using the backspace key on the terminal, it puts that ASCII character into the buffer.
+// 			This results in the string compare function failing.
+//			i.e. grww BS BS een, which results in green on the terminal
+//				however the buffer would look like grww@@een where the @'s are just placeholders for ASCII backspace
+bool strings_compare_colors_case_insensitive(const char* string_1, const char* string_2)
+{
+	char char_1, char_2;
+	
+	// Keep comparing the strings as long as they're not NULL
+	while(*string_1 && *string_2)
+	{
+		// Converting uppercase characters to lower case characters
+		if(*string_1 >= 'A' && *string_1 <= 'Z')
+		{
+			char_1 = *string_1 - 'A' + 'a';
+		}
+		else
+		{
+			char_1 = *string_1;
+		}
+		
+		if(*string_2 >= 'A' && *string_2 <= 'Z')
+		{
+			char_2 = *string_2 - 'A' + 'a';
+		}
+		else
+		{
+			char_2 = *string_2;
+		}
+		
+		// If at any point the characters are a mismatch
+		//	return 1 to say they are not equal
+		if(char_1 != char_2)
+		{
+			// busy_wait_write_string("Strings are NOT equal.\n");
+			return false;
+		}
+		
+		// increment the pointers to keep the check going
+		string_1++;
+		string_2++;
+	}
+	// if both strings start with the same string but are of different lengths,
+	//	this also means they are not equal, so return 1
+	//	i.e. "hello" and "helloworld"
+	if(*string_1 || *string_2)
+	{
+		// busy_wait_write_string("Strings are NOT equal.\n");
+		return false;
+	}
+	
+	// if all of the checks pass, then they are the same string so return 0
+	// busy_wait_write_string("Strings are equal.\n");
+	return true;
+}

--- a/colors.h
+++ b/colors.h
@@ -1,0 +1,28 @@
+#ifndef COLORS_H
+#define COLORS_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include "tm4c123gh6pm.h"    // Device header
+#include "uart_interrupt.h"
+#include "led.h"
+
+// Enum used to return the color code to flash the correct LED color
+typedef enum Colors
+{
+	NO_COLOR,
+	RED,
+	BLUE,
+	GREEN,
+	YELLOW,
+	PINK,
+	CYAN,
+	WHITE,
+	BLACK
+} Colors;
+
+Colors get_color(char* static_buffer, unsigned long length, unsigned long* ptr, bool* string_complete);
+void led_turn_on_color(Colors led_color);
+bool strings_compare_colors_case_insensitive(const char* string_1, const char* string_2);
+#endif	// COLORS_H
+

--- a/led.c
+++ b/led.c
@@ -30,7 +30,7 @@ void port_f_initialization(void)
 // red      --R-    0x02
 // blue     -B--    0x04
 // green    G---    0x08
-// pink			-BR-    0x05
+// pink			-BR-    0x06
 // yellow		G-R-    0x0A
 // cyan			GB--    0x0C
 // white		GBR-    0x0E

--- a/main.c
+++ b/main.c
@@ -1,17 +1,18 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include "led.h"
-#include "uart_busy_wait.h"
 #include "uart_interrupt.h"
 #include "systick.h"
 #include "test.h"
+#include "colors.h"
 
 int main(void)
 {
 	//char buffer[100];
-	unsigned char color[100];			// static buffer to hold color strings such as "red", "blue", etc
+	char color[100];			// static buffer to hold color strings such as "red", "blue", etc
 	unsigned long color_ptr = 0;	// pointer to keep track of the color buffer to "build" the string properly
 	bool string_complete = false;	// flag to check if string was completely built after user hit enter, used to reset color_ptr
+	Colors led_color;
 	systick_initialization();
 	port_f_initialization();
 	uart0_interrupt_initialization();
@@ -20,7 +21,10 @@ int main(void)
 	// main loop
 	while(1)
 	{
-		uart0_interrupt_get_string(color, 100, &color_ptr, &string_complete);
+		led_color = get_color(color, 100, &color_ptr, &string_complete);
+		led_turn_on_color(led_color);
+
+		// uart0_interrupt_get_string(color, 100, &color_ptr, &string_complete);
 	}
 }
 

--- a/uart_interrupt.c
+++ b/uart_interrupt.c
@@ -127,7 +127,7 @@ void UART0_Handler(void)
 	// If receive interrupt bit 4 is set in the MIS register, put the received data into the rx_ring_buffer
 	if (UART0_MIS_R & 0x10)
 	{
-		GPIO_PORTF_DATA_R = 0x02;		// set red LED to confirm it entered the receive interrupt if statement
+		// GPIO_PORTF_DATA_R = 0x02;		// set red LED to confirm it entered the receive interrupt if statement
 		
 		// Acknowledge receive interrupt
 		uart0_interrupt_clear_receive();
@@ -146,7 +146,7 @@ void UART0_Handler(void)
 	// If transmit interrupt bit 5 is set in the MIS register
 	if (UART0_MIS_R & 0x20)
 	{
-		GPIO_PORTF_DATA_R = 0x08;		// set green LED to confirm transmit interrupt triggered
+		// GPIO_PORTF_DATA_R = 0x08;		// set green LED to confirm transmit interrupt triggered
 		
 		// Acknowledge transmit receive interrupt
 		uart0_interrupt_clear_transmit();
@@ -233,7 +233,7 @@ void uart0_interrupt_send_char(struct ring_buffer* rb, unsigned char c)
 // string_complete = flag to check whether the string has been successfully built after user hits enter. This function is called
 //	non-blocking without using a loop, so it needs to know when to reset the buffer ptr back to 0 so the buffer doesn't hold
 // 	multiple colors inside of it and rebuilds the string starting from the 0 index
-void uart0_interrupt_get_string(unsigned char* static_buffer, unsigned long length, unsigned long* ptr, bool* string_complete)
+void uart0_interrupt_get_string(char* static_buffer, unsigned long length, unsigned long* ptr, bool* string_complete)
 {
 	unsigned char c;			// used to read in character from rx_ring_buffer
 
@@ -243,13 +243,6 @@ void uart0_interrupt_get_string(unsigned char* static_buffer, unsigned long leng
 	{
 		c = ring_buffer_read(&rx_ring_buffer) & 0xFF;			// read in the character
 		uart0_interrupt_send_char(&tx_ring_buffer, c);		// display the character immediately
-		
-		// If the user completed typing a string in the previous iteration, then we should reset the pointer
-		// 	to build the string properly on the next iteration starting from the beginning of the buffer
-		if (*string_complete == true)
-		{
-			*ptr = 0;
-		}
 		
 		// If its a backspace character, in Putty it is sent as 'DEL' which is 0x7F,
 		//	decrement static buffer index so the string isn't destroyed by holding the junk character

--- a/uart_interrupt.h
+++ b/uart_interrupt.h
@@ -13,7 +13,7 @@ void uart0_interrupt_clear_receive(void);
 void uart0_interrupt_clear_transmit(void);
 bool uart0_interrupt_get_char(struct ring_buffer* rb, unsigned char* c);
 void uart0_interrupt_send_char(struct ring_buffer* rb, unsigned char c);
-void uart0_interrupt_get_string(unsigned char* buffer, unsigned long length, unsigned long* ptr, bool* string_complete);
+void uart0_interrupt_get_string(char* buffer, unsigned long length, unsigned long* ptr, bool* string_complete);
 //bool get_char(uint8_t *c);
 //void send_char(uint8_t c);
 


### PR DESCRIPTION
Three functions were implemented to turn on one of the 8 possible LED colors on the launchpad.

get_color()
It calls the uart0_interrupt_get_string() function to build the string in the colors[] array and returns an enum color to be passed into the next function.

led_turn_on_color()
It uses the enum color parameter as a switch statement argument to turn on the corresponding color on the launchpad LED.

strings_compare_colors_case_insensitive()
This function was brought over from the uart_busy_wait.c file. It was slightly modified to return a boolean to improve code readability.

TODO: Add string prompts on the terminal such as "Enter color: " or "invalid color entered..."